### PR TITLE
Added openSUSE games

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,8 @@
 			sudo add-apt-repository ppa:stratagus<br>
 			sudo apt-get update<br>
 			sudo apt-get install wargus<br><br>
+			<div class=linuxDlLabel>openSUSE Games</div>
+			See <a href="https://software.opensuse.org/package/wargus">software.opensuse.org</a><br><br>
 			<div class=linuxDlLabel>Other Linux</div>
 			See FAQ about linux packages and building from sources
 		</div>


### PR DESCRIPTION
https://software.opensuse.org/package/wargus makes it available via a convenient 1-Click-Install.